### PR TITLE
closes #39

### DIFF
--- a/pmml/step1_prepare/step1_2_preprocess_data.py
+++ b/pmml/step1_prepare/step1_2_preprocess_data.py
@@ -45,6 +45,10 @@ print(basename(__file__), f'storybooks_dataframe (after dropping missing values)
 
 # Extract number from reading level (e.g. 'LEVEL1' --> '1')
 storybooks_dataframe['reading_level'] = storybooks_dataframe['reading_level'].str.extract('(\\d+)')
+
+# Convert the categorical reading_level variable into 0/1
+storybooks_dataframe['reading_level'] = pandas.get_dummies(storybooks_dataframe['reading_level'])
+
 print(basename(__file__), f'storybooks_dataframe (after converting texts to numbers): \n{storybooks_dataframe}')
 
 # Write the DataFrame to a CSV file


### PR DESCRIPTION
Convert the categorical reading_level variable into 0/1

### Issue Number
<!-- Which issue does this PR address? E.g. "Resolves #123" -->
* Resolves #39

### Purpose
<!-- What is the purpose of this PR? Why is it needed? -->
* To test if this one-hot encoding technique would result in a better accuracy score.
### Technical Details
<!-- Are there any key aspects of the implementation to highlight? -->
* 

### Testing Instructions
<!-- How can the reviewer verify the functionality or fix introduced by this PR? Please provide steps. -->
* 

### Screenshots
<!-- If this PR affects the UI, please include before/after screenshots demonstrating the change(s). -->
*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced data preprocessing by adding one-hot encoding for the `reading_level` variable, improving data transformation for analysis.

- **Bug Fixes**
	- Improved traceability of data transformations with added print statements to monitor DataFrame states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->