### PR TITLE
Convert reading_level into dummy variables

### DIFF
--- a/pmml/step1_prepare/step1_2_preprocess_data.py
+++ b/pmml/step1_prepare/step1_2_preprocess_data.py
@@ -45,6 +45,14 @@ print(basename(__file__), f'storybooks_dataframe (after dropping missing values)
 
 # Extract number from reading level (e.g. 'LEVEL1' --> '1')
 storybooks_dataframe['reading_level'] = storybooks_dataframe['reading_level'].str.extract('(\\d+)')
+
+# Convert 'reading_level' into dummy variables
+storybooks_dataframe = pandas.concat(
+    [storybooks_dataframe.drop(columns=['reading_level']),  # Drop the original reading_level column
+     pandas.get_dummies(storybooks_dataframe['reading_level'], prefix='reading_level')],  # Add dummy columns
+    axis=1
+)
+
 print(basename(__file__), f'storybooks_dataframe (after converting texts to numbers): \n{storybooks_dataframe}')
 
 # Write the DataFrame to a CSV file


### PR DESCRIPTION
### Issue Number
<!-- Which issue does this PR address? E.g. "Resolves #123" -->
* Resolves #39

### Purpose
<!-- What is the purpose of this PR? Why is it needed? -->
* The purpose of this PR is to convert the ```reading_level```column into dummy variables (binary columns) using ```pandas.get_dummies```, while retaining all other columns in the DataFrame.

### Technical Details
<!-- Are there any key aspects of the implementation to highlight? -->
* 

### Testing Instructions
<!-- How can the reviewer verify the functionality or fix introduced by this PR? Please provide steps. -->
* 

### Screenshots
<!-- If this PR affects the UI, please include before/after screenshots demonstrating the change(s). -->
*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced data preprocessing by converting the `reading_level` column into dummy variables for improved analysis.
  
- **Bug Fixes**
	- Added print statements to log the DataFrame's state post-conversion, aiding in debugging and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->