### PR TITLE
test(pmml): enforce minimum accuracy score

### DIFF
--- a/.github/workflows/pmml-nightly.yml
+++ b/.github/workflows/pmml-nightly.yml
@@ -3,6 +3,7 @@ name: Python application (PMML, Nightly Build)
 on:
   schedule:
     - cron: 22 10 * * *
+  workflow_dispatch:
 
 jobs:
   build:

--- a/pmml/step3_predict/step3_2_validate.py
+++ b/pmml/step3_predict/step3_2_validate.py
@@ -3,6 +3,7 @@ import pandas
 from pypmml import Model
 from sklearn.metrics import mean_absolute_error
 from sklearn.metrics import accuracy_score
+from utils.accuracy_utils import validate_accuracy_score
 
 # Load Predictive Model Markup Language (PMML) model
 model_pmml_path = '../step2_train/step2_2_model.pmml'
@@ -37,6 +38,7 @@ with open('step3_2_mean_absolute_error.txt', 'w') as file:
 # Calculate the accuracy score
 accuracy_score = accuracy_score(val_y, val_predictions)
 print(basename(__file__), f'accuracy_score: {accuracy_score}')
+validate_accuracy_score(accuracy_score)
 
 # Write the accuracy score to a text file
 with open('step3_2_accuracy_score.txt', 'w') as file:

--- a/pmml/utils/accuracy_utils.py
+++ b/pmml/utils/accuracy_utils.py
@@ -1,6 +1,6 @@
 import math
 
-MIN_ACCURACY_SCORE = 0.75
+MIN_ACCURACY_SCORE = 0.80  # Temporarily raised for smoke testing; revert to 0.75 after verification
 
 
 def validate_accuracy_score(accuracy_score, min_accuracy_score=MIN_ACCURACY_SCORE):

--- a/pmml/utils/accuracy_utils.py
+++ b/pmml/utils/accuracy_utils.py
@@ -1,0 +1,9 @@
+MIN_ACCURACY_SCORE = 0.75
+
+
+def validate_accuracy_score(accuracy_score, min_accuracy_score=MIN_ACCURACY_SCORE):
+    if accuracy_score < min_accuracy_score:
+        raise ValueError(
+            f'Accuracy score {accuracy_score:.4f} is below the minimum required score '
+            f'of {min_accuracy_score:.4f}'
+        )

--- a/pmml/utils/accuracy_utils.py
+++ b/pmml/utils/accuracy_utils.py
@@ -1,7 +1,13 @@
+import math
+
 MIN_ACCURACY_SCORE = 0.75
 
 
 def validate_accuracy_score(accuracy_score, min_accuracy_score=MIN_ACCURACY_SCORE):
+    if not isinstance(accuracy_score, (int, float)) or not math.isfinite(accuracy_score):
+        raise ValueError('Accuracy score must be a finite number')
+    if not 0.0 <= accuracy_score <= 1.0:
+        raise ValueError(f'Accuracy score {accuracy_score:.4f} must be between 0.0000 and 1.0000')
     if accuracy_score < min_accuracy_score:
         raise ValueError(
             f'Accuracy score {accuracy_score:.4f} is below the minimum required score '

--- a/pmml/utils/accuracy_utils.py
+++ b/pmml/utils/accuracy_utils.py
@@ -4,7 +4,7 @@ MIN_ACCURACY_SCORE = 0.75
 
 
 def validate_accuracy_score(accuracy_score, min_accuracy_score=MIN_ACCURACY_SCORE):
-    if not isinstance(accuracy_score, (int, float)) or not math.isfinite(accuracy_score):
+    if isinstance(accuracy_score, bool) or not isinstance(accuracy_score, (int, float)) or not math.isfinite(accuracy_score):
         raise ValueError('Accuracy score must be a finite number')
     if not 0.0 <= accuracy_score <= 1.0:
         raise ValueError(f'Accuracy score {accuracy_score:.4f} must be between 0.0000 and 1.0000')

--- a/pmml/utils/accuracy_utils.py
+++ b/pmml/utils/accuracy_utils.py
@@ -1,6 +1,6 @@
 import math
 
-MIN_ACCURACY_SCORE = 0.80  # Temporarily raised for smoke testing; revert to 0.75 after verification
+MIN_ACCURACY_SCORE = 0.75
 
 
 def validate_accuracy_score(accuracy_score, min_accuracy_score=MIN_ACCURACY_SCORE):

--- a/pmml/utils/test_accuracy_utils.py
+++ b/pmml/utils/test_accuracy_utils.py
@@ -2,8 +2,12 @@ import math
 
 import pytest
 
-from utils.accuracy_utils import MIN_ACCURACY_SCORE
-from utils.accuracy_utils import validate_accuracy_score
+try:
+    from utils.accuracy_utils import MIN_ACCURACY_SCORE
+    from utils.accuracy_utils import validate_accuracy_score
+except ModuleNotFoundError:
+    from accuracy_utils import MIN_ACCURACY_SCORE
+    from accuracy_utils import validate_accuracy_score
 
 
 def test_validate_accuracy_score_accepts_scores_at_threshold():

--- a/pmml/utils/test_accuracy_utils.py
+++ b/pmml/utils/test_accuracy_utils.py
@@ -1,7 +1,9 @@
+import math
+
 import pytest
 
-from accuracy_utils import MIN_ACCURACY_SCORE
-from accuracy_utils import validate_accuracy_score
+from utils.accuracy_utils import MIN_ACCURACY_SCORE
+from utils.accuracy_utils import validate_accuracy_score
 
 
 def test_validate_accuracy_score_accepts_scores_at_threshold():
@@ -15,3 +17,15 @@ def test_validate_accuracy_score_accepts_scores_above_threshold():
 def test_validate_accuracy_score_rejects_scores_below_threshold():
     with pytest.raises(ValueError, match='below the minimum required score'):
         validate_accuracy_score(0.74)
+
+
+def test_validate_accuracy_score_rejects_non_finite_scores():
+    for value in (math.nan, math.inf, -math.inf):
+        with pytest.raises(ValueError, match='finite number'):
+            validate_accuracy_score(value)
+
+
+def test_validate_accuracy_score_rejects_scores_outside_unit_range():
+    for value in (-0.1, 1.1):
+        with pytest.raises(ValueError, match='between 0.0000 and 1.0000'):
+            validate_accuracy_score(value)

--- a/pmml/utils/test_accuracy_utils.py
+++ b/pmml/utils/test_accuracy_utils.py
@@ -1,0 +1,17 @@
+import pytest
+
+from accuracy_utils import MIN_ACCURACY_SCORE
+from accuracy_utils import validate_accuracy_score
+
+
+def test_validate_accuracy_score_accepts_scores_at_threshold():
+    validate_accuracy_score(MIN_ACCURACY_SCORE)
+
+
+def test_validate_accuracy_score_accepts_scores_above_threshold():
+    validate_accuracy_score(0.95)
+
+
+def test_validate_accuracy_score_rejects_scores_below_threshold():
+    with pytest.raises(ValueError, match='below the minimum required score'):
+        validate_accuracy_score(0.74)

--- a/pmml/utils/test_accuracy_utils.py
+++ b/pmml/utils/test_accuracy_utils.py
@@ -29,7 +29,13 @@ def test_validate_accuracy_score_rejects_non_finite_scores():
             validate_accuracy_score(value)
 
 
+def test_validate_accuracy_score_rejects_bool_scores():
+    for value in (True, False):
+        with pytest.raises(ValueError, match='finite number'):
+            validate_accuracy_score(value)
+
+
 def test_validate_accuracy_score_rejects_scores_outside_unit_range():
     for value in (-0.1, 1.1):
-        with pytest.raises(ValueError, match='between 0.0000 and 1.0000'):
+        with pytest.raises(ValueError, match=r'between 0\.0000 and 1\.0000'):
             validate_accuracy_score(value)


### PR DESCRIPTION
### Issue Number
* Resolves #27

### Purpose
* Fail the PMML build when the model accuracy score drops below 75%.

### Technical Details
* Adds a small accuracy validation helper with a `0.75` minimum threshold.
* Calls the helper after calculating `accuracy_score` in `step3_2_validate.py`, so `python run_all_steps.py` fails if the threshold is not met.
* Adds unit tests for scores below, at, and above the threshold.

### Testing Instructions
* `pytest utils/test_accuracy_utils.py utils/test_chapters_utils.py`
* `pytest`
* `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
* `python run_all_steps.py`

### Screenshots
* N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added accuracy-score validation to the prediction workflow before saving results.
  * Accuracy scores must be finite numeric values between **0.0000** and **1.0000**, and must meet a minimum threshold of **0.7500** (unless configured otherwise).

* **Tests**
  * Expanded automated tests to confirm acceptance at/above the threshold.
  * Added coverage for rejection of below-threshold values, non-finite inputs (NaN/±Inf), boolean inputs, and out-of-range scores.

* **Chores**
  * Enabled manual runs for the nightly workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->